### PR TITLE
Fix $.MTAppOtherTypeCategories TYPO

### DIFF
--- a/MTAppjQuery/mt-static/plugins/MTAppjQuery/js/MTAppjQuery.js
+++ b/MTAppjQuery/mt-static/plugins/MTAppjQuery/js/MTAppjQuery.js
@@ -4333,7 +4333,7 @@
                                 }
                             }
                             if (i == 0 && !op.selected) {
-                                _html.push('<select name="other-type-category"><option value=""' + attrDefChecked + attrDisabled + attrHiddenClass + '>未選択</option>');
+                                _html.push('<select name="other-type-category"><option value=""' + attrDefChecked + attrDisabled + attrHiddenClass + '>' + op.notSelectedText+ '</option>');
                             }
                             _html.push('<option value="' + catId + '"' + attrChecked + attrDisabled + attrHiddenClass + '>' + catLabel + '</option>');
                             break;


### PR DESCRIPTION
$.MTAppOtherTypeCategories で `type: 'select'` の場合に、`notSelectedText` を指定してもプルダウンのテキストが「未選択」のままになってしまうため、該当箇所を修正しました。